### PR TITLE
Gracefully handle exceptions in thread tunneling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ workspace.code-workspace
 
 # log files
 .pnpm-debug.log
+
+# Local virtualenv for devs
+.venv*

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -12,6 +12,7 @@ import warnings
 import webbrowser
 from types import ModuleType
 from typing import TYPE_CHECKING, Any, AnyStr, Callable, Dict, List, Optional, Tuple
+from queue import Empty as EmptyQueueException  # not to confuse with gradio.queue
 
 import anyio
 import requests
@@ -35,7 +36,7 @@ from gradio.documentation import (
     set_documentation_group,
 )
 from gradio.exceptions import DuplicateBlockError
-from gradio.tunneling_poc import create_tunnel
+from gradio.tunneling_poc import create_tunnel, BACKGROUND_TUNNEL_EXCEPTIONS
 from gradio.utils import component_or_layout_class, delete_none
 
 set_documentation_group("blocks")
@@ -1280,7 +1281,11 @@ class Blocks(BlockContext):
             while True:
                 time.sleep(0.1)
         except (KeyboardInterrupt, OSError):
-            print("Keyboard interruption in main thread... closing server.")
+            try:
+                _ = BACKGROUND_TUNNEL_EXCEPTIONS.get_nowait()
+                print("Exception occurred in tunnel connection... closing server.")
+            except EmptyQueueException:
+                print("Keyboard interruption in main thread... closing server.")
             self.server.close()
 
     def attach_load_events(self):


### PR DESCRIPTION
I've made some tests over the work from @XciD and created a `start_as_daemon_thread` helper to "gracefully" handle exceptions in children threads in tunneling_poc:
- Background threads are now started as ["daemon"](https://docs.python.org/3/library/threading.html#threading.Thread.daemon) which means they are immediately terminated when the main thread is stopped.
- If the main thread is terminated (with `KeyboardInterrupt`), the daemon threads are terminated but not properly. In particular, the **socket connection to the FRP server is not carefully closed**. Is this a problem ? Another solution would be to use [Events](https://docs.python.org/3/library/threading.html#threading.Event) but I don't know how to make it work with `frps_client.recv()` and `frps_client.send()`.
- If an exception is raised in a child thread, I raise a `KeyboardInterrup` in the main thread using [`_thread.interrupt_main`](https://docs.python.org/3/library/_thread.html#thread.interrupt_main) which is a quite low-level but still valid solution. The exception is propagated using a `queue.Queue` so that the main thread knows the exception comes from a child thread.

Otherwise I tested the solution on a basic gradio example and it worked fine (connected from my phone for instance). I haven't tested extensively the Gradio part as I assume it works same as before.